### PR TITLE
Two new new activities, one optional parameter

### DIFF
--- a/h1/models.py
+++ b/h1/models.py
@@ -491,8 +491,10 @@ class ActivityComment(ActivityBase):
 class ActivityCommentsClosed(ActivityBase):
     TYPE = "activity-comments-closed"
 
+
 class ActivityCveIdAdded(ActivityBase):
-    TYPE="activity-cve-id-added"
+    TYPE = "activity-cve-id-added"
+
 
 class ActivityExternalUserInvitationCancelled(ActivityBase):
     TYPE = "activity-external-user-invitation-cancelled"
@@ -540,8 +542,10 @@ class ActivityManuallyDisclosed(ActivityBase):
 class ActivityMediationRequested(ActivityBase):
     TYPE = "activity-mediation-requested"
 
+
 class ActivityNobodyAssignedToBug(ActivityBase):
     TYPE = "activity-nobody-assigned-to-bug"
+
 
 class ActivityNotEligibleForBounty(ActivityBase):
     TYPE = "activity-not-eligible-for-bounty"

--- a/h1/models.py
+++ b/h1/models.py
@@ -512,7 +512,7 @@ class ActivityExternalUserJoined(ActivityBase):
     TYPE = "activity-external-user-joined"
 
     def _activity_hydrate(self):
-        self._make_attribute("duplicate_report_id", self._hydrate_verbatim)
+        self._make_attribute("duplicate_report_id", self._hydrate_verbatim, optional=True)
 
 
 class ActivityExternalUserRemoved(ActivityBase):

--- a/h1/models.py
+++ b/h1/models.py
@@ -491,6 +491,8 @@ class ActivityComment(ActivityBase):
 class ActivityCommentsClosed(ActivityBase):
     TYPE = "activity-comments-closed"
 
+class ActivityCveIdAdded(ActivityBase):
+    TYPE="activity-cve-id-added"
 
 class ActivityExternalUserInvitationCancelled(ActivityBase):
     TYPE = "activity-external-user-invitation-cancelled"
@@ -538,6 +540,8 @@ class ActivityManuallyDisclosed(ActivityBase):
 class ActivityMediationRequested(ActivityBase):
     TYPE = "activity-mediation-requested"
 
+class ActivityNobodyAssignedToBug(ActivityBase):
+    TYPE = "activity-nobody-assigned-to-bug"
 
 class ActivityNotEligibleForBounty(ActivityBase):
     TYPE = "activity-not-eligible-for-bounty"


### PR DESCRIPTION
Hi there,

I just used the h1 module to retrieve a bunch of reports out of HackerOne. It worked quite well, but I hit into three separate exceptions on different records. 

1. activity-cve-id-added
2. activity-nobody-assigned-to-bug
3. duplicate_report_id should be optional

The two activities are present in the data although they are undocumented in the H1 API docs. I also ran across at least one report object that contained an activity-external-user-joined object without the duplicate_report_id attribute, so it seems like marking it as optional is the obvious fix.


