### PR TITLE
Feature/add new activities

### DIFF
--- a/h1/models.py
+++ b/h1/models.py
@@ -491,8 +491,10 @@ class ActivityComment(ActivityBase):
 class ActivityCommentsClosed(ActivityBase):
     TYPE = "activity-comments-closed"
 
+
 class ActivityCveIdAdded(ActivityBase):
-    TYPE="activity-cve-id-added"
+    TYPE = "activity-cve-id-added"
+
 
 class ActivityExternalUserInvitationCancelled(ActivityBase):
     TYPE = "activity-external-user-invitation-cancelled"
@@ -540,8 +542,10 @@ class ActivityManuallyDisclosed(ActivityBase):
 class ActivityMediationRequested(ActivityBase):
     TYPE = "activity-mediation-requested"
 
+
 class ActivityNobodyAssignedToBug(ActivityBase):
     TYPE = "activity-nobody-assigned-to-bug"
+
 
 class ActivityNotEligibleForBounty(ActivityBase):
     TYPE = "activity-not-eligible-for-bounty"

--- a/h1/models.py
+++ b/h1/models.py
@@ -512,7 +512,7 @@ class ActivityExternalUserJoined(ActivityBase):
     TYPE = "activity-external-user-joined"
 
     def _activity_hydrate(self):
-        self._make_attribute("duplicate_report_id", self._hydrate_verbatim)
+        self._make_attribute("duplicate_report_id", self._hydrate_verbatim, optional=True)
 
 
 class ActivityExternalUserRemoved(ActivityBase):

--- a/h1/models.py
+++ b/h1/models.py
@@ -491,6 +491,8 @@ class ActivityComment(ActivityBase):
 class ActivityCommentsClosed(ActivityBase):
     TYPE = "activity-comments-closed"
 
+class ActivityCveIdAdded(ActivityBase):
+    TYPE="activity-cve-id-added"
 
 class ActivityExternalUserInvitationCancelled(ActivityBase):
     TYPE = "activity-external-user-invitation-cancelled"
@@ -538,6 +540,8 @@ class ActivityManuallyDisclosed(ActivityBase):
 class ActivityMediationRequested(ActivityBase):
     TYPE = "activity-mediation-requested"
 
+class ActivityNobodyAssignedToBug(ActivityBase):
+    TYPE = "activity-nobody-assigned-to-bug"
 
 class ActivityNotEligibleForBounty(ActivityBase):
     TYPE = "activity-not-eligible-for-bounty"

--- a/tests/resources/activity-cve-id-added.json
+++ b/tests/resources/activity-cve-id-added.json
@@ -1,0 +1,30 @@
+{
+    "type": "activity-cve-id-added",
+    "id": "1337",
+    "attributes": {
+        "message": "",
+        "created_at": "2016-02-02T04:05:06.000Z",
+        "updated_at": "2016-02-02T04:05:06.000Z",
+        "internal": false
+    },
+    "relationships": {
+        "actor": {
+            "data": {
+                "type": "user",
+                "id": "1337",
+                "attributes": {
+                    "username": "api-example",
+                    "name": "API Example",
+                    "disabled": false,
+                    "created_at": "2016-02-02T04:05:06.000Z",
+                    "profile_picture": {
+                      "62x62": "/assets/avatars/default.png",
+                      "82x82": "/assets/avatars/default.png",
+                      "110x110": "/assets/avatars/default.png",
+                      "260x260": "/assets/avatars/default.png"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/resources/activity-nobody-assigned-to-bug.json
+++ b/tests/resources/activity-nobody-assigned-to-bug.json
@@ -1,5 +1,5 @@
 {
-    "type": "aactivity-nobody-assigned-to-bug",
+    "type": "activity-nobody-assigned-to-bug",
     "id": "1337",
     "attributes": {
         "message": "",

--- a/tests/resources/activity-nobody-assigned-to-bug.json
+++ b/tests/resources/activity-nobody-assigned-to-bug.json
@@ -1,0 +1,30 @@
+{
+    "type": "aactivity-nobody-assigned-to-bug",
+    "id": "1337",
+    "attributes": {
+        "message": "",
+        "created_at": "2016-02-02T04:05:06.000Z",
+        "updated_at": "2016-02-02T04:05:06.000Z",
+        "internal": false
+    },
+    "relationships": {
+        "actor": {
+            "data": {
+                "type": "user",
+                "id": "1337",
+                "attributes": {
+                    "username": "api-example",
+                    "name": "API Example",
+                    "disabled": false,
+                    "created_at": "2016-02-02T04:05:06.000Z",
+                    "profile_picture": {
+                      "62x62": "/assets/avatars/default.png",
+                      "82x82": "/assets/avatars/default.png",
+                      "110x110": "/assets/avatars/default.png",
+                      "260x260": "/assets/avatars/default.png"
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hi there,

(resubmitting #6 after fixing lint warnings)

I just used the h1 module to retrieve a bunch of reports out of HackerOne. It worked quite well, but I hit into three separate exceptions on different records.

activity-cve-id-added
activity-nobody-assigned-to-bug
duplicate_report_id should be optional
The two activities are present in the data although they are undocumented in the H1 API docs. I also ran across at least one report object that contained an activity-external-user-joined object without the duplicate_report_id attribute, so it seems like marking it as optional is the obvious fix.